### PR TITLE
Aws profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ as terraform seems to have trouble otherwise.
 Speaking of which, copy the variable.tf_TEMPLATE to variable.tf, and modify as necessary.
 Certainly change the credentials file path, and the subnets if you want to.
 
+Validate the terraform will work as you expect
+```
+terraform plan
+terraform apply
+```
+
 Once the ami is launched, the userdata script will:
 - Rename the computer
 - Disable UAC, IE ESC, and the firewall
@@ -33,6 +39,22 @@ Once the ami is launched, the userdata script will:
     - DirectX and audio library installers
 - Blow away the standard display driver, so steam is forced to use the nvidia one (not sure if this is necessary)
 
+You will need to do the following (ToDo-Automation):
+- Install/Configure Hamachi
+  - It is reccommended to create a 'Mesh Network' and join the machine to it
+- Install Razer Surround
+  - You may want to disable the service 'Razer Game Scanner'
+- Extract and run the DriectX Library installer
+- Login to Steam
+  - Create a Steam Library on the ephemeral disk (Z:\)
+  - Install Some Games
+- Create a Desktop shortcut which will disconnect your RDP but leave session unlocked for Steam Streaming:
+  - `C:\Windows\system32\tscon.exe %sessionname% /dest:console`
+
 Restart the computer after you verify it's good (also on the TODO automation list)
 
+
 A good resource to use: http://www.win2012workstation.com/
+Other Good Resources:
+  - http://lg.io/2015/07/05/revised-and-much-faster-run-your-own-highend-cloud-gaming-service-on-ec2.html
+  - https://www.reddit.com/r/cloudygamer/

--- a/provider.tf
+++ b/provider.tf
@@ -5,5 +5,6 @@
 
 provider "aws" {
   shared_credentials_file = "${var.cred_file}"
+  profile                 = "${var.cred_profile}"
   region                  = "us-east-1"
 }

--- a/variables.tf_TEMPLATE
+++ b/variables.tf_TEMPLATE
@@ -29,7 +29,7 @@ variable "cidr_block_subnet_private" {
 }
 
 variable "cidr_block_subnet_public" {
-  default = "192.168.15.160/27""
+  default = "192.168.15.160/27"
 }
 
 # This is the cidr block for the network allowed to access the ec2 instance.

--- a/variables.tf_TEMPLATE
+++ b/variables.tf_TEMPLATE
@@ -11,6 +11,10 @@ variable "cred_file" {
   default = "/Users/yourname/.aws/credentials-gamingaws"
 }
 
+variable "cred_profile" {
+  default = "default"
+}
+
 # Make sure the vpc network range encompasses the subnet ranges.
 variable "cidr_block_vpc" {
   default = "192.168.15.0/24"

--- a/variables.tf_TEMPLATE
+++ b/variables.tf_TEMPLATE
@@ -11,6 +11,10 @@ variable "cred_file" {
   default = "/Users/yourname/.aws/credentials-gamingaws"
 }
 
+# Update this if you are using a single credential file
+# with multiple credentials by profile name.  We'll assume you
+# are using a single specific credential file with a [default]
+# profile configured
 variable "cred_profile" {
   default = "default"
 }


### PR DESCRIPTION
## Additions

- AWS Credential Profile Support
- More README

The credential profiles are successfully working off my main `~/.aws/credentials` and a named profile `gaming`.  I left the default in the template through so that someone can use the reccommended separate file.